### PR TITLE
リサイズ時と列番設定器の不具合修正

### DIFF
--- a/ATSDisplay/LEDWindow.cs
+++ b/ATSDisplay/LEDWindow.cs
@@ -241,7 +241,10 @@ namespace TatehamaATS_v1.ATSDisplay
         private void LEDWindow_ResizeEnd(object sender, EventArgs e) {
             var newWidth = ClientSize.Width;
             var newHeight = ClientSize.Height;
-            if ((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
+            if(newHeight < 155) {
+                newHeight = originSize.Height * newWidth / originSize.Width;
+            }
+            else if ((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
                 newWidth = originSize.Width * newHeight / originSize.Height;
             }
             else if ((float)originSize.Width / originSize.Height > (float)newWidth / newHeight) {

--- a/KokuchiWindow/KokuchiWindow.cs
+++ b/KokuchiWindow/KokuchiWindow.cs
@@ -461,7 +461,10 @@ namespace TatehamaATS_v1.KokuchiWindow
         private void KokuchiWindow_ResizeEnd(object sender, EventArgs e) {
             var newWidth = ClientSize.Width;
             var newHeight = ClientSize.Height;
-            if((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
+            if (newWidth <= 0 || newHeight <= 0) {
+                return;
+            }
+            if ((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
                 newWidth = originSize.Width * newHeight / originSize.Height;
             }
             else if ((float)originSize.Width / originSize.Height > (float)newWidth / newHeight) {

--- a/RetsubanWindow/TimeLogic.cs
+++ b/RetsubanWindow/TimeLogic.cs
@@ -161,7 +161,7 @@ namespace TatehamaATS_v1.RetsubanWindow
             switch (Name)
             {
                 case "Set":
-                    if (nowSetting)
+                    if (nowSetting && NewHour.Length > 0)
                     {
                         var newHour = Int32.Parse(NewHour);
                         newHour = newHour + 24;


### PR DESCRIPTION
- 告知器リサイズで表示領域面積が0になった際に落ちる不具合を修正
- 列番設定器の時刻設定で何も入力せずに設定ボタンを押すと落ちる不具合を修正
- ATS表示器を小さくしすぎると扱いづらくなるため、小さくなりすぎないように制約を追加