### PR TITLE
リサイズ時と列番設定器の不具合修正

### DIFF
--- a/ATSDisplay/LEDWindow.cs
+++ b/ATSDisplay/LEDWindow.cs
@@ -241,7 +241,10 @@ namespace TatehamaATS_v1.ATSDisplay
         private void LEDWindow_ResizeEnd(object sender, EventArgs e) {
             var newWidth = ClientSize.Width;
             var newHeight = ClientSize.Height;
-            if ((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
+            if(newHeight < 155) {
+                newHeight = originSize.Height * newWidth / originSize.Width;
+            }
+            else if ((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
                 newWidth = originSize.Width * newHeight / originSize.Height;
             }
             else if ((float)originSize.Width / originSize.Height > (float)newWidth / newHeight) {

--- a/KokuchiWindow/KokuchiWindow.cs
+++ b/KokuchiWindow/KokuchiWindow.cs
@@ -288,12 +288,7 @@ namespace TatehamaATS_v1.KokuchiWindow
         private void DisplayImageByPos(int x, int y, int width = 48, int height = 16) {
             var Image = GetImageByPos(x, y, width, height);
             var BigImage = EnlargePixelArt(Image);
-            var oldImage = ledOrigin;
-            ledOrigin = BigImage;
-            oldImage?.Dispose();
-            oldImage = KokuchiLED.BackgroundImage;
-            KokuchiLED.BackgroundImage = new Bitmap(BigImage, KokuchiLED.Size);
-            oldImage?.Dispose();
+            DisplayImage(BigImage);
 
         }
 
@@ -313,11 +308,31 @@ namespace TatehamaATS_v1.KokuchiWindow
                     g.DrawImage(S1, 24, 0, S1.Width, S1.Height);
                 }
                 var BigImage = EnlargePixelArt(De);
-                KokuchiLED.BackgroundImage = BigImage;
+                DisplayImage(BigImage);
             }
             else {
                 DisplayImageByPos(1, 171);
             }
+        }
+
+        /// <summary>
+        /// 拡大縮小して画像出す
+        /// </summary>
+        /// <param name="bigImage">出す画像</param>
+        private void DisplayImage(Bitmap bigImage) {
+            var oldOrigin = ledOrigin;
+            ledOrigin = bigImage;
+            oldOrigin?.Dispose();
+            DisplayImage();
+        }
+
+        /// <summary>
+        /// 既に出ている画像をリサイズする
+        /// </summary>
+        private void DisplayImage() {
+            var oldImage = KokuchiLED.BackgroundImage;
+            KokuchiLED.BackgroundImage = new Bitmap(ledOrigin, KokuchiLED.Size);
+            oldImage?.Dispose();
         }
 
         /// <summary>
@@ -479,15 +494,12 @@ namespace TatehamaATS_v1.KokuchiWindow
 
             KokuchiLED.Location = new Point(ledLocation.X * newHeight / originSize.Height, ledLocation.Y * newHeight / originSize.Height);
             KokuchiLED.Size = new Size(ledSize.Width * newHeight / originSize.Height, ledSize.Height * newHeight / originSize.Height);
-            oldImage = KokuchiLED.BackgroundImage;
-            KokuchiLED.BackgroundImage = new Bitmap(ledOrigin, KokuchiLED.Size);
-            oldImage?.Dispose();
+            DisplayImage();
             oldImage = KokuchiLED.Image;
             KokuchiLED.Image = new Bitmap(KokuchiResource.KokuchiLED_Waku, KokuchiLED.Size);
             oldImage?.Dispose();
 
 
-            /*Transparency.Size = kokuchiSize;*/
             oldImage = Transparency.Image;
             Transparency.Image = new Bitmap(KokuchiResource.Kokuchi_Transparency, kokuchiSize);
             oldImage?.Dispose();

--- a/KokuchiWindow/KokuchiWindow.cs
+++ b/KokuchiWindow/KokuchiWindow.cs
@@ -461,7 +461,10 @@ namespace TatehamaATS_v1.KokuchiWindow
         private void KokuchiWindow_ResizeEnd(object sender, EventArgs e) {
             var newWidth = ClientSize.Width;
             var newHeight = ClientSize.Height;
-            if((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
+            if (newWidth <= 0 || newHeight <= 0) {
+                return;
+            }
+            if ((float)originSize.Width / originSize.Height < (float)newWidth / newHeight) {
                 newWidth = originSize.Width * newHeight / originSize.Height;
             }
             else if ((float)originSize.Width / originSize.Height > (float)newWidth / newHeight) {

--- a/RetsubanWindow/TimeLogic.cs
+++ b/RetsubanWindow/TimeLogic.cs
@@ -161,7 +161,7 @@ namespace TatehamaATS_v1.RetsubanWindow
             switch (Name)
             {
                 case "Set":
-                    if (nowSetting)
+                    if (nowSetting && NewHour.Length > 0)
                     {
                         var newHour = Int32.Parse(NewHour);
                         newHour = newHour + 24;


### PR DESCRIPTION
- 告知器リサイズで表示領域面積が0になった際に落ちる不具合を修正
- 列番設定器の時刻設定で何も入力せずに設定ボタンを押すと落ちる不具合を修正
- ATS表示器を小さくしすぎると扱いづらくなるため、小さくなりすぎないように制約を追加
- 出発時刻表示が拡大縮小されない不具合を修正